### PR TITLE
Fixed URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,4 @@ Inside the `<!-- Tab Panels -->` section, place the code to load the notificatio
 
 Log into your Spark application and access the new notifications tab located at:
 
-`http://your-spark.url/settings#/notifications`
+`http://your-spark.url/spark/kiosk#/notifications`


### PR DESCRIPTION
In Spark, the kiosk views are pulled from the kiosk route. So just to be clear at this point ^^